### PR TITLE
Change how icon_url gets its URL

### DIFF
--- a/start.js
+++ b/start.js
@@ -5,7 +5,7 @@ const Discord = require('discord.js');
 const { statuses, build, release, prefix, token, footerTxt } = require('./config.json');
 
 const embedFooter = {
-  "icon_url": "https://cdn.discordapp.com/attachments/549707869138714635/793524910172667964/Screenshot_26.png",
+  "icon_url": message.author.displayAvatarURL(),
   "text": footerTxt
 }
 


### PR DESCRIPTION
Anitrox started getting the icon from the user that executed the command in 1.0, and some bits still haven't actually been updated to use the new method